### PR TITLE
Set up project scaffolding and database layer

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -1,0 +1,122 @@
+"""Database connection utilities for the lotto_ai4 project.
+
+This module centralises database connectivity logic so that the rest of the
+application can work with a single, well tested API.  It uses SQLAlchemy's
+engine abstraction to manage pooled connections to the MySQL database and
+exposes a helper for executing read-only queries in a safe, parameterised
+manner.
+"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine, Result, URL
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
+
+
+class DatabaseConfigurationError(RuntimeError):
+    """Raised when the database configuration is incomplete."""
+
+
+@lru_cache(maxsize=1)
+def get_db_engine() -> Engine:
+    """Create (or retrieve) a cached SQLAlchemy engine for MySQL.
+
+    The connection settings are read from environment variables so they can be
+    customised per deployment.  Defaults are provided to make local development
+    straightforward, while still allowing overrides in production.
+
+    Environment variables:
+        DB_HOST: MySQL host. Defaults to ``localhost``.
+        DB_PORT: MySQL port. Defaults to ``3306``.
+        DB_USER: Database username. Defaults to ``root``.
+        DB_PASS: Database password. Defaults to an empty string.
+        DB_NAME: Database name. Defaults to ``lotto_3d``.
+
+    Returns:
+        Engine: A SQLAlchemy engine configured for read-only operations.
+    """
+
+    host = os.getenv("DB_HOST", "localhost")
+    port_raw = os.getenv("DB_PORT", "3306")
+    user = os.getenv("DB_USER", "root")
+    password = os.getenv("DB_PASS", "")
+    database = os.getenv("DB_NAME", "lotto_3d")
+
+    if not user:
+        raise DatabaseConfigurationError("DB_USER must be provided")
+
+    try:
+        port = int(port_raw)
+    except (TypeError, ValueError) as exc:
+        raise DatabaseConfigurationError("DB_PORT must be a valid integer") from exc
+
+    url = URL.create(
+        "mysql+pymysql",
+        username=user,
+        password=password or None,
+        host=host,
+        port=port,
+        database=database,
+    )
+
+    # ``init_command`` runs for every new connection and sets the session to be
+    # read-only. This guards against accidental data modification and enforces
+    # the read-only default required by the project.
+    connect_args = {
+        "charset": "utf8mb4",
+        "init_command": "SET SESSION TRANSACTION READ ONLY",
+    }
+
+    try:
+        engine = create_engine(url, pool_pre_ping=True, connect_args=connect_args)
+    except SQLAlchemyError as exc:  # pragma: no cover - failure is propagated
+        raise DatabaseConfigurationError("Failed to create database engine") from exc
+
+    return engine
+
+
+def query_db(sql: str, params: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:
+    """Execute a parameterised, read-only SQL query.
+
+    Args:
+        sql: A SQL statement that must represent a ``SELECT`` query.
+        params: Parameter dictionary passed to the SQL statement.  If omitted,
+            an empty mapping is used so that SQLAlchemy can still treat the
+            execution as parameterised.
+
+    Returns:
+        A list of dictionaries where each dictionary represents a row.
+
+    Raises:
+        ValueError: If the statement is not a ``SELECT`` query.
+        SQLAlchemyError: If there is an error executing the query.
+    """
+
+    if not sql:
+        raise ValueError("SQL query must not be empty")
+
+    # Enforce read-only access by ensuring the query starts with SELECT.
+    if not sql.strip().lower().startswith("select"):
+        raise ValueError("Only SELECT queries are permitted in query_db")
+
+    engine = get_db_engine()
+    compiled_sql = text(sql)
+    bound_params = params or {}
+
+    try:
+        with engine.connect() as connection:
+            result: Result = connection.execute(compiled_sql, bound_params)
+            rows = [dict(row._mapping) for row in result.fetchall()]
+    except OperationalError as exc:
+        # Re-raise operational errors with the original context so callers can
+        # decide how to handle the failure (e.g. retry, surface a message, etc.).
+        raise OperationalError(sql, bound_params, exc.orig) from exc
+
+    return rows
+
+
+__all__ = ["get_db_engine", "query_db", "DatabaseConfigurationError"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+sqlalchemy
+pymysql
+pandas
+numpy

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,57 @@
+"""Basic integration tests for database access and utilities."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+from db.connection import get_db_engine
+from utils.pagination import paginate
+
+
+@pytest.mark.integration
+def test_database_connection():
+    """Ensure that a database connection can be established.
+
+    The test attempts to run a trivial ``SELECT 1`` against the configured
+    database.  When executed in environments without access to MySQL the test is
+    skipped rather than failed so that local development without a database
+    remains possible.
+    """
+
+    engine = get_db_engine()
+
+    try:
+        with engine.connect() as connection:
+            result = connection.execute(text("SELECT 1"))
+            assert result.scalar() == 1
+    except OperationalError as exc:  # pragma: no cover - depends on env setup
+        pytest.skip(f"Database unavailable: {exc}")
+
+
+@pytest.mark.parametrize(
+    "page,page_size,expected_limit,expected_offset",
+    [
+        (1, 10, 10, 0),
+        (2, 25, 25, 25),
+        (5, 50, 50, 200),
+    ],
+)
+def test_paginate(page: int, page_size: int, expected_limit: int, expected_offset: int):
+    """Verify pagination calculations."""
+
+    pagination = paginate(page=page, page_size=page_size)
+
+    assert pagination.limit == expected_limit
+    assert pagination.offset == expected_offset
+    assert pagination.page == page
+    assert pagination.page_size == page_size
+
+
+def test_paginate_invalid_arguments():
+    """Invalid pagination arguments should raise :class:`ValueError`."""
+
+    with pytest.raises(ValueError):
+        paginate(0, 10)
+    with pytest.raises(ValueError):
+        paginate(1, 0)

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,34 @@
+"""Streamlit caching utilities used across the application."""
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, TypeVar
+
+import streamlit as st
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def cache_data(ttl: Optional[int] = 600, **kwargs: Any) -> Callable[[F], F]:
+    """A thin wrapper around :func:`streamlit.cache_data`.
+
+    The wrapper applies a sensible default TTL and keeps the API consistent
+    across the codebase.  Additional keyword arguments are forwarded directly to
+    ``st.cache_data`` for fine-grained control when required.
+
+    Args:
+        ttl: Time-to-live for the cached data in seconds. ``None`` disables
+            expiration. Defaults to ``600`` seconds (10 minutes).
+        **kwargs: Additional options passed to :func:`streamlit.cache_data`.
+
+    Returns:
+        Callable: A decorator that can be applied to data loading functions.
+    """
+
+    def decorator(func: F) -> F:
+        cached_function = st.cache_data(ttl=ttl, **kwargs)(func)
+        return cached_function  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = ["cache_data"]

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,0 +1,42 @@
+"""Utility helpers for paginating database result sets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Pagination:
+    """Represents pagination parameters derived from page settings."""
+
+    page: int
+    page_size: int
+    limit: int
+    offset: int
+
+
+def paginate(page: int, page_size: int) -> Pagination:
+    """Calculate pagination information.
+
+    Args:
+        page: 1-based index of the requested page.
+        page_size: Number of records per page.
+
+    Returns:
+        Pagination: Dataclass containing page, page_size, limit and offset.
+
+    Raises:
+        ValueError: If ``page`` or ``page_size`` are less than 1.
+    """
+
+    if page < 1:
+        raise ValueError("page must be greater than or equal to 1")
+    if page_size < 1:
+        raise ValueError("page_size must be greater than or equal to 1")
+
+    limit = page_size
+    offset = (page - 1) * page_size
+
+    return Pagination(page=page, page_size=page_size, limit=limit, offset=offset)
+
+
+__all__ = ["Pagination", "paginate"]


### PR DESCRIPTION
## Summary
- add project scaffolding directories and dependency list
- implement MySQL connection helpers with read-only safeguards
- add utility modules for pagination and Streamlit caching with accompanying tests

## Testing
- pytest *(fails: missing optional dependency `sqlalchemy` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc563d21008328bf2a5739b8da7d45